### PR TITLE
navbar now toggles topbar rather than toggler, whitespace edits, holiday note added

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
         <div class='sb'>
             <h3 class="text-white">Spec links</h3>
             <div class='sbc'>
-                <a target='_blank' href="https://filestore.aqa.org.uk/resources/biology/specifications/AQA-8461-SP-2016.PDF" class="text-white">Biology</a><br>                
+                <a target='_blank' href="https://filestore.aqa.org.uk/resources/biology/specifications/AQA-8461-SP-2016.PDF" class="text-white">Biology</a><br>
                 <a target='_blank' href="https://filestore.aqa.org.uk/resources/chemistry/specifications/AQA-8462-SP-2016.PDF" class="text-white">Chemistry</a><br>
                 <a target='_blank' href='https://filestore.aqa.org.uk/resources/science/specifications/AQA-8464-SP-2016.PDF' class='text-white'>Combined Science</a><br>
                 <a target='_blank' href="https://www.ocr.org.uk/Images/558027-specification-gcse-computer-science-j277.pdf" class="text-white">Computer Science</a><br>
@@ -30,8 +30,6 @@
                 <a target='_blank' href="https://filestore.aqa.org.uk/resources/geography/specifications/AQA-8035-SP-2016.PDF" class="text-white">Geography</a><br>
                 <a target='_blank' href="https://qualifications.pearson.com/content/dam/pdf/GCSE/History/2016/specification-and-sample-assessments/gcse-9-1-history-specification.pdf" class="text-white">History</a><br>
                 <a target='_blank' href="https://qualifications.pearson.com/content/dam/pdf/GCSE/mathematics/2015/specification-and-sample-assesment/gcse-maths-2015-specification.pdf" class="text-white">Maths</a><br>
-                
-
             </div>
             <div class='sbc'>
                 <a target='_blank' href="https://qualifications.pearson.com/content/dam/pdf/GCSE/Music/2016/specification/Pearson_Edexcel_GCSE_9_to_1_in_Music_Specification_issue4.pdf" class="text-white">Music</a><br>
@@ -42,18 +40,13 @@
             </div>
         </div>
       </div>
-      <div class="container-fluid">
-          <button class="navbar-toggler t" type="button" data-bs-toggle="collapse" data-bs-target="#sls">
-            <span class="navbar-toggler-icon"></span>
-          </button>
-          <h2 class="navbar-brand text-white">GCSE Timetable 2024</h2>
+      <div class="container-fluid navbar-toggler" data-bs-toggle="collapse" data-bs-target="#sls">
+          <h2 class="navbar-brand text-white navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#sls">GCSE Timetable 2024</h2>
       </div>
     </nav>
     </div>
     <br>
-    <p><del>hello</del> assalaamucalaykum world</p>
-    <br>
-    <p class='note rounded'>:D <strong>You made it!</strong></p>
+    <p class='note rounded'>Holidays are between the <strong>24th May and 3rd June!</strong></p>
     <br>
     <br>
       <div class='eqc rounded'>


### PR DESCRIPTION
i'm very very verrry gassed because ALXAMDULILLAAH MY TITLE IS CENTERED!!! Of course it took me a bit of work and thinking but on a break while walking around and talking with my family about this issue it struck me! The WHOLE navbar can be clicked anywhere to toggle the entire topbar, and atp I think I can stop thinking of making the topbar into a sidebar quite happily!!!

Also removed whitespace/blank lines and added holiday note (didn't realise the holiday note was a new edit till I checked the preview and edits whoops!)
this fixes #3 - i'm experimenting to see if this will close issue automatically when merged!!! bismillaah